### PR TITLE
Pass channel params on leave events

### DIFF
--- a/assets/js/phoenix/channel.js
+++ b/assets/js/phoenix/channel.js
@@ -212,7 +212,7 @@ export default class Channel {
       if(this.socket.hasLogger()) this.socket.log("channel", `leave ${this.topic}`)
       this.trigger(CHANNEL_EVENTS.close, "leave")
     }
-    let leavePush = new Push(this, CHANNEL_EVENTS.leave, closure({}), timeout)
+    let leavePush = new Push(this, CHANNEL_EVENTS.leave, this.params, timeout)
     leavePush.receive("ok", () => onClose())
       .receive("timeout", () => onClose())
     leavePush.send()

--- a/assets/test/channel_test.js
+++ b/assets/test/channel_test.js
@@ -972,6 +972,7 @@ describe("with transport", function(){
   describe("leave", function(){
     let clock
     let socketSpy
+    const chanParams = {one: "two"}
 
     beforeEach(function(){
       clock = sinon.useFakeTimers()
@@ -980,7 +981,7 @@ describe("with transport", function(){
       sinon.stub(socket, "isConnected").callsFake(() => true)
       socketSpy = sinon.stub(socket, "push")
 
-      channel = socket.channel("topic", {one: "two"})
+      channel = socket.channel("topic", chanParams)
       channel.join().trigger("ok", {})
     })
 
@@ -997,7 +998,7 @@ describe("with transport", function(){
       assert.ok(socketSpy.calledWith({
         topic: "topic",
         event: "phx_leave",
-        payload: {},
+        payload: chanParams,
         ref: defaultRef,
         join_ref: joinRef
       }))


### PR DESCRIPTION
TGF-1439
**background**
ls is set up to handle `phx_leave` events that include channel params -- we'll want to pass these through on the client.

**changes**
Support passing channel params through on `phx_leave` events

**testing**
red/green unit test