### PR TITLE
Allow configuration of dynamic socket timeout

### DIFF
--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -47,6 +47,11 @@ defmodule Phoenix.Transports.WebSocket do
         keys = Keyword.get(opts, :connect_info, [])
         connect_info = Transport.connect_info(conn, endpoint, keys)
 
+        opts = case Keyword.fetch!(opts, :timeout) do
+            {m, f, a} -> Keyword.put(opts, :timeout, apply(m, f, a))
+            _ -> opts
+          end
+
         config = %{
           endpoint: endpoint,
           transport: :websocket,

--- a/test/phoenix/integration/websocket_socket_test.exs
+++ b/test/phoenix/integration/websocket_socket_test.exs
@@ -102,7 +102,7 @@ defmodule Phoenix.Integration.WebSocketTest do
     socket "/ws/ping", PingSocket,
       websocket: true
 
-    def websocket_timeout, do: 300
+    def websocket_timeout, do: 50
   end
 
   setup_all do
@@ -172,6 +172,9 @@ defmodule Phoenix.Integration.WebSocketTest do
     {:ok, client} = WebsocketClient.connect(self(), path, :noop)
     WebsocketClient.send(client, {:text, "ping"})
     assert_receive {:text, "pong"}
+
+    Process.sleep(100)
+    refute Process.alive?(client)
   end
 
   test "allows a path with variables" do

--- a/test/phoenix/integration/websocket_socket_test.exs
+++ b/test/phoenix/integration/websocket_socket_test.exs
@@ -91,12 +91,18 @@ defmodule Phoenix.Integration.WebSocketTest do
       websocket: [path: "nested/path", check_origin: ["//example.com"], timeout: 200],
       custom: :value
 
+    socket "/custom/timeout", UserSocket,
+      websocket: [path: "/", timeout: {Endpoint, :websocket_timeout, []}],
+      custom: :value
+
     socket "/custom/:socket_var", UserSocket,
       websocket: [path: ":path_var/path", check_origin: ["//example.com"], timeout: 200],
       custom: :value
 
     socket "/ws/ping", PingSocket,
       websocket: true
+
+    def websocket_timeout, do: 300
   end
 
   setup_all do
@@ -159,6 +165,13 @@ defmodule Phoenix.Integration.WebSocketTest do
   test "allows a custom path" do
     path = "ws://127.0.0.1:#{@port}/custom/some_path/nested/path"
     assert {:ok, _} = WebsocketClient.connect(self(), "#{path}?key=value", :noop)
+  end
+
+  test "websocket timeout can be provided via MFA" do
+    path = "ws://127.0.0.1:#{@port}/custom/timeout/"
+    {:ok, client} = WebsocketClient.connect(self(), path, :noop)
+    WebsocketClient.send(client, {:text, "ping"})
+    assert_receive {:text, "pong"}
   end
 
   test "allows a path with variables" do


### PR DESCRIPTION
We want to be able to dynamically configure the websocket idle timeout limit.
Right now it's compile time only, so I'm extending it so we're able to provide an MFA tuple that will be evaluated when a new socket is opened.