### PR TITLE
DX-22 update GHA runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: 1.12.0
-            otp: 22.3
+          - elixir: 1.16.0
+            otp: 26
 
           - elixir: 1.14.3
             otp: 25.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           - elixir: 1.16.3
-            otp: 24.3
+            otp: 26.2
 
           - elixir: 1.14.3
             otp: 25.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             lint: true
             installer: true
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             lint: true
             installer: true
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: 1.16.0
-            otp: 26
+          - elixir: 1.16.3
+            otp: 24.3
 
           - elixir: 1.14.3
             otp: 25.1


### PR DESCRIPTION
GitHub is retiring ubuntu-20.04 runners, so we need to replace them. Didn't upgrade to 22.04 since the `npm test` job breaks. Removed old version of OTP/Elixir and replaced with version we're actually using rn in LS.