### PR TITLE
Change [:phoenix, :endpoint, :broadcast] event

### DIFF
--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -292,22 +292,22 @@ defmodule Phoenix.Endpoint.EndpointTest do
     some = spawn fn -> :ok end
 
     Endpoint.broadcast_from(some, "atopic", "event1", %{key: :val})
-    assert_receive {:telemetry, _, %{}, %{subscribers: [{^me, nil}], message: %{topic: "atopic", event: "event1", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{}, %{subscriber_count: 1, message: %{topic: "atopic", event: "event1", payload: %{key: :val}}}}
 
     Endpoint.broadcast_from!(some, "atopic", "event2", %{key: :val})
-    assert_receive {:telemetry, _, %{}, %{subscribers: [{^me, nil}], message: %{topic: "atopic", event: "event2", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{}, %{subscriber_count: 1, message: %{topic: "atopic", event: "event2", payload: %{key: :val}}}}
 
     Endpoint.broadcast("atopic", "event3", %{key: :val})
-    assert_receive {:telemetry, _, %{}, %{subscribers: [{^me, nil}], message: %{topic: "atopic", event: "event3", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{}, %{subscriber_count: 1, message: %{topic: "atopic", event: "event3", payload: %{key: :val}}}}
 
     Endpoint.broadcast!("atopic", "event4", %{key: :val})
-    assert_receive {:telemetry, _, %{}, %{subscribers: [{^me, nil}], message: %{topic: "atopic", event: "event4", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{}, %{subscriber_count: 1, message: %{topic: "atopic", event: "event4", payload: %{key: :val}}}}
 
     Endpoint.local_broadcast_from(some, "atopic", "event5", %{key: :val})
-    assert_receive {:telemetry, _, %{}, %{subscribers: [{^me, nil}], message: %{topic: "atopic", event: "event5", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{}, %{subscriber_count: 1, message: %{topic: "atopic", event: "event5", payload: %{key: :val}}}}
 
     Endpoint.local_broadcast("atopic", "event6", %{key: :val})
-    assert_receive {:telemetry, _, %{}, %{subscribers: [{^me, nil}], message: %{topic: "atopic", event: "event6", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{}, %{subscriber_count: 1, message: %{topic: "atopic", event: "event6", payload: %{key: :val}}}}
   end
 
   test "loads cache manifest from specified application" do

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -284,10 +284,6 @@ defmodule Phoenix.Endpoint.EndpointTest do
       nil
     )
 
-    Endpoint.broadcast!("atopic", "event1", %{key: :val})
-
-    refute_receive {:telemetry, _, _, _}
-
     Endpoint.subscribe("atopic")
     some = spawn fn -> :ok end
 
@@ -308,6 +304,10 @@ defmodule Phoenix.Endpoint.EndpointTest do
 
     Endpoint.local_broadcast("atopic", "event6", %{key: :val})
     assert_receive {:telemetry, _, %{}, %{subscriber_count: 1, message: %{topic: "atopic", event: "event6", payload: %{key: :val}}}}
+
+    Endpoint.unsubscribe("atopic")
+    Endpoint.broadcast("atopic", "event7", %{key: :val})
+    refute_receive {:telemetry, _, _, _}
   end
 
   test "emits telemetry event on pubsub broadcast with multiple subscribers", ctx do

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -324,16 +324,17 @@ defmodule Phoenix.Endpoint.EndpointTest do
       nil
     )
 
+    Endpoint.subscribe("multi_topic")
     Enum.each(1..2, fn _ ->
       spawn fn ->
-        Endpoint.subscribe("atopic")
+        Endpoint.subscribe("multi_topic")
         Process.sleep(5000)
         :ok
       end
     end)
 
-    Endpoint.broadcast("atopic", "event1", %{key: :val})
-    assert_receive {:telemetry, _, %{}, %{subscriber_count: 2, message: %{topic: "atopic", event: "event1", payload: %{key: :val}}}}
+    Endpoint.broadcast("multi_topic", "event1", %{key: :val})
+    assert_receive {:telemetry, _, %{}, %{subscriber_count: 3, message: %{topic: "multi_topic", event: "event1", payload: %{key: :val}}}}
   end
 
   test "loads cache manifest from specified application" do


### PR DESCRIPTION
Ticket: https://whatnot.atlassian.net/browse/PE-152

We're not really using the list of subscribers so instead we'd like to report the count of subscribers so than in live-service we can report it as a metric.

This would allow us to know how many messages a broadcast really entails.