### PR TITLE
Adjust [:phoenix, :endpoint, :broadcast] event

### DIFF
--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -121,8 +121,8 @@ defmodule Phoenix.Channel.Server do
 
     :telemetry.execute(
       [:phoenix, :endpoint, :broadcast],
-      %{},
-      %{subscriber_count: subscriber_count, message: Map.from_struct(msg)}
+      %{subscriber_count: subscriber_count},
+      %{message: Map.from_struct(msg)}
     )
 
     :ok

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -288,22 +288,22 @@ defmodule Phoenix.Endpoint.EndpointTest do
     some = spawn fn -> :ok end
 
     Endpoint.broadcast_from(some, "atopic", "event1", %{key: :val})
-    assert_receive {:telemetry, _, %{}, %{subscriber_count: 1, message: %{topic: "atopic", event: "event1", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{message: %{topic: "atopic", event: "event1", payload: %{key: :val}}}}
 
     Endpoint.broadcast_from!(some, "atopic", "event2", %{key: :val})
-    assert_receive {:telemetry, _, %{}, %{subscriber_count: 1, message: %{topic: "atopic", event: "event2", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{message: %{topic: "atopic", event: "event2", payload: %{key: :val}}}}
 
     Endpoint.broadcast("atopic", "event3", %{key: :val})
-    assert_receive {:telemetry, _, %{}, %{subscriber_count: 1, message: %{topic: "atopic", event: "event3", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{message: %{topic: "atopic", event: "event3", payload: %{key: :val}}}}
 
     Endpoint.broadcast!("atopic", "event4", %{key: :val})
-    assert_receive {:telemetry, _, %{}, %{subscriber_count: 1, message: %{topic: "atopic", event: "event4", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{message: %{topic: "atopic", event: "event4", payload: %{key: :val}}}}
 
     Endpoint.local_broadcast_from(some, "atopic", "event5", %{key: :val})
-    assert_receive {:telemetry, _, %{}, %{subscriber_count: 1, message: %{topic: "atopic", event: "event5", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{message: %{topic: "atopic", event: "event5", payload: %{key: :val}}}}
 
     Endpoint.local_broadcast("atopic", "event6", %{key: :val})
-    assert_receive {:telemetry, _, %{}, %{subscriber_count: 1, message: %{topic: "atopic", event: "event6", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{message: %{topic: "atopic", event: "event6", payload: %{key: :val}}}}
 
     Endpoint.unsubscribe("atopic")
     Endpoint.broadcast("atopic", "event7", %{key: :val})
@@ -321,9 +321,9 @@ defmodule Phoenix.Endpoint.EndpointTest do
       nil
     )
 
-    Endpoint.subscribe("atopic")
+    Endpoint.subscribe("anothertopic")
     spawn fn ->
-      Endpoint.subscribe("atopic")
+      Endpoint.subscribe("anothertopic")
       send(me, :subscribed)
 
       Process.sleep(5000)
@@ -333,8 +333,8 @@ defmodule Phoenix.Endpoint.EndpointTest do
     # makes sure that subscription in spawned process happens before broadcast
     assert_receive :subscribed
 
-    Endpoint.broadcast("atopic", "event1", %{key: :val})
-    assert_receive {:telemetry, _, %{}, %{subscriber_count: 2, message: %{topic: "atopic", event: "event1", payload: %{key: :val}}}}
+    Endpoint.broadcast("anothertopic", "event1", %{key: :val})
+    assert_receive {:telemetry, _, %{subscriber_count: 2}, %{message: %{topic: "anothertopic", event: "event1", payload: %{key: :val}}}}
   end
 
   test "loads cache manifest from specified application" do


### PR DESCRIPTION
I've realized that to use the subscriber count as a metric value I need to put it in measurements map, not in metadata.