### PR TITLE
Add subscribers to broadcast event metadata

### DIFF
--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -122,7 +122,7 @@ defmodule Phoenix.Channel.Server do
     :telemetry.execute(
       [:phoenix, :endpoint, :broadcast],
       %{subscriber_count: subscriber_count},
-      %{message: Map.from_struct(msg)}
+      %{subscribers: subscribers, message: Map.from_struct(msg)}
     )
 
     :ok

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -288,22 +288,22 @@ defmodule Phoenix.Endpoint.EndpointTest do
     some = spawn fn -> :ok end
 
     Endpoint.broadcast_from(some, "atopic", "event1", %{key: :val})
-    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{message: %{topic: "atopic", event: "event1", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{subscribers: [{^me, nil}], message: %{topic: "atopic", event: "event1", payload: %{key: :val}}}}
 
     Endpoint.broadcast_from!(some, "atopic", "event2", %{key: :val})
-    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{message: %{topic: "atopic", event: "event2", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{subscribers: [{^me, nil}], message: %{topic: "atopic", event: "event2", payload: %{key: :val}}}}
 
     Endpoint.broadcast("atopic", "event3", %{key: :val})
-    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{message: %{topic: "atopic", event: "event3", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{subscribers: [{^me, nil}], message: %{topic: "atopic", event: "event3", payload: %{key: :val}}}}
 
     Endpoint.broadcast!("atopic", "event4", %{key: :val})
-    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{message: %{topic: "atopic", event: "event4", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{subscribers: [{^me, nil}], message: %{topic: "atopic", event: "event4", payload: %{key: :val}}}}
 
     Endpoint.local_broadcast_from(some, "atopic", "event5", %{key: :val})
-    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{message: %{topic: "atopic", event: "event5", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{subscribers: [{^me, nil}], message: %{topic: "atopic", event: "event5", payload: %{key: :val}}}}
 
     Endpoint.local_broadcast("atopic", "event6", %{key: :val})
-    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{message: %{topic: "atopic", event: "event6", payload: %{key: :val}}}}
+    assert_receive {:telemetry, _, %{subscriber_count: 1}, %{subscribers: [{^me, nil}], message: %{topic: "atopic", event: "event6", payload: %{key: :val}}}}
 
     Endpoint.unsubscribe("atopic")
     Endpoint.broadcast("atopic", "event7", %{key: :val})
@@ -322,7 +322,7 @@ defmodule Phoenix.Endpoint.EndpointTest do
     )
 
     Endpoint.subscribe("anothertopic")
-    spawn fn ->
+    pid = spawn fn ->
       Endpoint.subscribe("anothertopic")
       send(me, :subscribed)
 

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -322,7 +322,7 @@ defmodule Phoenix.Endpoint.EndpointTest do
     )
 
     Endpoint.subscribe("anothertopic")
-    pid = spawn fn ->
+    spawn fn ->
       Endpoint.subscribe("anothertopic")
       send(me, :subscribed)
 


### PR DESCRIPTION
When adding `subscribers_count` I've removed the `subscribers` list, however I've realized that some of our events in `EventBus` use it.